### PR TITLE
Add LINQ OrderBy examples

### DIFF
--- a/Linq/CustomComparerOrderByExample.cs
+++ b/Linq/CustomComparerOrderByExample.cs
@@ -1,0 +1,39 @@
+namespace LinqExamples;
+
+public static class CustomComparerOrderByExample
+{
+    private sealed class StringLengthComparer : IComparer<string>
+    {
+        public int Compare(string? x, string? y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return 0;
+            }
+
+            if (x is null)
+            {
+                return -1;
+            }
+
+            if (y is null)
+            {
+                return 1;
+            }
+
+            int lengthComparison = x.Length.CompareTo(y.Length);
+
+            return lengthComparison != 0 ? lengthComparison : string.Compare(x, y, StringComparison.Ordinal);
+        }
+    }
+
+    public static void Execute()
+    {
+        List<string> parole = new() { "albero", "sole", "computer", "casa", "programmazione", "penna" };
+
+        IEnumerable<string> paroleOrdinataPerLunghezza = parole.OrderBy(p => p, new StringLengthComparer());
+
+        Console.WriteLine("OrderBy con comparatore custom - Parole ordinate per lunghezza: " + string.Join(", ", paroleOrdinataPerLunghezza));
+        Console.WriteLine();
+    }
+}

--- a/Linq/OrderByExample.cs
+++ b/Linq/OrderByExample.cs
@@ -1,0 +1,14 @@
+namespace LinqExamples;
+
+public static class OrderByExample
+{
+    public static void Execute()
+    {
+        List<int> valori = new() { 42, 7, 19, 73, 3, 27 };
+
+        IEnumerable<int> valoriOrdinati = valori.OrderBy(v => v);
+
+        Console.WriteLine("OrderBy - Valori ordinati in modo crescente: " + string.Join(", ", valoriOrdinati));
+        Console.WriteLine();
+    }
+}

--- a/Linq/Program.cs
+++ b/Linq/Program.cs
@@ -16,5 +16,7 @@ class Program
         WhereObjectsExample.Execute();
         FirstLastElementAtSingleExample.Execute();
         AllAnyContainsExample.Execute();
+        OrderByExample.Execute();
+        CustomComparerOrderByExample.Execute();
     }
 }


### PR DESCRIPTION
## Summary
- add a basic LINQ OrderBy example that orders a list of integers
- demonstrate OrderBy with a custom IComparer to sort strings by length
- register the new examples in the main program

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cd0c09c7508324924106606ecb3424