### PR TITLE
Aggiungi esempi LINQ Join e GroupJoin

### DIFF
--- a/Linq/GroupJoinExample.cs
+++ b/Linq/GroupJoinExample.cs
@@ -1,0 +1,53 @@
+namespace LinqExamples;
+
+public record ClienteGroupJoin(int Id, string Nome);
+
+public record OrdineGroupJoin(int ClienteId, string Prodotto);
+
+public static class GroupJoinExample
+{
+    public static void Execute()
+    {
+        List<ClienteGroupJoin> clienti = new()
+        {
+            new(1, "Maria"),
+            new(2, "Luca"),
+            new(3, "Sara"),
+            new(4, "Giulia")
+        };
+
+        List<OrdineGroupJoin> ordini = new()
+        {
+            new(1, "Laptop"),
+            new(1, "Mouse"),
+            new(2, "Monitor"),
+            new(3, "Stampante")
+        };
+
+        IEnumerable<(string Cliente, IEnumerable<OrdineGroupJoin> Ordini)> ordiniPerCliente = clienti
+            .GroupJoin(
+                ordini,
+                cliente => cliente.Id,
+                ordine => ordine.ClienteId,
+                (cliente, ordiniCliente) => (cliente.Nome, ordiniCliente)
+            );
+
+        Console.WriteLine("GroupJoin - Ordini raggruppati per cliente:");
+        foreach ((string cliente, IEnumerable<OrdineGroupJoin> ordiniCliente) in ordiniPerCliente)
+        {
+            Console.WriteLine($"Cliente: {cliente}");
+            if (!ordiniCliente.Any())
+            {
+                Console.WriteLine("  Nessun ordine");
+                continue;
+            }
+
+            foreach (OrdineGroupJoin ordine in ordiniCliente)
+            {
+                Console.WriteLine($"  - {ordine.Prodotto}");
+            }
+        }
+
+        Console.WriteLine();
+    }
+}

--- a/Linq/JoinExample.cs
+++ b/Linq/JoinExample.cs
@@ -1,0 +1,42 @@
+namespace LinqExamples;
+
+public record ClienteJoin(int Id, string Nome);
+
+public record OrdineJoin(int ClienteId, string Prodotto);
+
+public static class JoinExample
+{
+    public static void Execute()
+    {
+        List<ClienteJoin> clienti = new()
+        {
+            new(1, "Maria"),
+            new(2, "Luca"),
+            new(3, "Sara")
+        };
+
+        List<OrdineJoin> ordini = new()
+        {
+            new(1, "Laptop"),
+            new(1, "Mouse"),
+            new(2, "Monitor"),
+            new(4, "Stampante")
+        };
+
+        IEnumerable<string> ordiniConCliente = clienti
+            .Join(
+                ordini,
+                cliente => cliente.Id,
+                ordine => ordine.ClienteId,
+                (cliente, ordine) => $"Cliente: {cliente.Nome} - Prodotto: {ordine.Prodotto}"
+            );
+
+        Console.WriteLine("Join - Ordini con relativo cliente:");
+        foreach (string risultato in ordiniConCliente)
+        {
+            Console.WriteLine("- " + risultato);
+        }
+
+        Console.WriteLine();
+    }
+}

--- a/Linq/Program.cs
+++ b/Linq/Program.cs
@@ -20,5 +20,7 @@ class Program
         CustomComparerOrderByExample.Execute();
         CountSumExample.Execute();
         MaxMinAverageExample.Execute();
+        JoinExample.Execute();
+        GroupJoinExample.Execute();
     }
 }


### PR DESCRIPTION
## Summary
- aggiunto un esempio dedicato all'operatore Join con liste di clienti e ordini
- illustrato l'uso di GroupJoin per raggruppare gli ordini per cliente
- registrata l'esecuzione dei nuovi esempi nel programma principale della sezione LINQ

## Testing
- dotnet build *(fallisce: comando non disponibile nell'ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68cd149321348324ab535326f8e0f89b