### PR TITLE
Add LINQ GroupBy examples

### DIFF
--- a/Linq/GroupByCategoryExample.cs
+++ b/Linq/GroupByCategoryExample.cs
@@ -1,0 +1,35 @@
+namespace LinqExamples;
+
+public record Libro(string Titolo, string Categoria);
+
+public static class GroupByCategoryExample
+{
+    public static void Execute()
+    {
+        List<Libro> libri = new()
+        {
+            new("Il Signore degli Anelli", "Fantasy"),
+            new("Harry Potter e la Pietra Filosofale", "Fantasy"),
+            new("Il Codice Da Vinci", "Thriller"),
+            new("Sherlock Holmes", "Giallo"),
+            new("1984", "Distopico"),
+            new("Fahrenheit 451", "Distopico"),
+            new("Angeli e Demoni", "Thriller")
+        };
+
+        IEnumerable<IGrouping<string, Libro>> libriPerCategoria = libri.GroupBy(libro => libro.Categoria);
+
+        Console.WriteLine("GroupBy - Libri raggruppati per categoria:");
+        foreach (IGrouping<string, Libro> gruppo in libriPerCategoria)
+        {
+            Console.WriteLine($"Categoria: {gruppo.Key}");
+
+            foreach (Libro libro in gruppo)
+            {
+                Console.WriteLine($"- {libro.Titolo}");
+            }
+
+            Console.WriteLine();
+        }
+    }
+}

--- a/Linq/GroupByParityExample.cs
+++ b/Linq/GroupByParityExample.cs
@@ -1,0 +1,19 @@
+namespace LinqExamples;
+
+public static class GroupByParityExample
+{
+    public static void Execute()
+    {
+        List<int> numeri = Enumerable.Range(1, 12).ToList();
+
+        IEnumerable<IGrouping<string, int>> gruppi = numeri.GroupBy(n => n % 2 == 0 ? "Pari" : "Dispari");
+
+        Console.WriteLine("GroupBy - Numeri raggruppati per parità:");
+        foreach (IGrouping<string, int> gruppo in gruppi)
+        {
+            Console.WriteLine($"{gruppo.Key}: {string.Join(", ", gruppo)}");
+        }
+
+        Console.WriteLine();
+    }
+}

--- a/Linq/Program.cs
+++ b/Linq/Program.cs
@@ -20,5 +20,7 @@ class Program
         CustomComparerOrderByExample.Execute();
         CountSumExample.Execute();
         MaxMinAverageExample.Execute();
+        GroupByParityExample.Execute();
+        GroupByCategoryExample.Execute();
     }
 }


### PR DESCRIPTION
## Summary
- add a GroupBy example that divides numbers by parity
- add a GroupBy example that groups books by category
- invoke the new examples from the LINQ program entry point

## Testing
- dotnet build *(fails: `dotnet` command not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd147eec588324b6da4da472cb0331