### PR TITLE
Add LINQ examples for Take/Skip and set operations

### DIFF
--- a/Linq/Program.cs
+++ b/Linq/Program.cs
@@ -23,5 +23,7 @@ class Program
         GroupByCategoryExample.Execute();
         JoinExample.Execute();
         GroupJoinExample.Execute();
+        TakeSkipExample.Execute();
+        SetOperationsExample.Execute();
     }
 }

--- a/Linq/SetOperationsExample.cs
+++ b/Linq/SetOperationsExample.cs
@@ -1,0 +1,19 @@
+public static class SetOperationsExample
+{
+    public static void Execute()
+    {
+        List<string> fruttaEstiva = new() { "Pesca", "Albicocca", "Ciliegia", "Anguria", "Pesca" };
+        List<string> fruttaInvernale = new() { "Arancia", "Mela", "Pera", "Cachi", "Ciliegia" };
+
+        IEnumerable<string> fruttaSenzaDuplicati = fruttaEstiva.Distinct();
+        IEnumerable<string> fruttaDiTutteLeStagioni = fruttaEstiva.Union(fruttaInvernale);
+        IEnumerable<string> fruttaInComune = fruttaEstiva.Intersect(fruttaInvernale);
+        IEnumerable<string> soloEstiva = fruttaEstiva.Except(fruttaInvernale);
+
+        Console.WriteLine("Distinct - Frutta estiva senza duplicati: " + string.Join(", ", fruttaSenzaDuplicati));
+        Console.WriteLine("Union - Frutta disponibile in entrambe le stagioni: " + string.Join(", ", fruttaDiTutteLeStagioni));
+        Console.WriteLine("Intersect - Frutta presente in entrambe le liste: " + string.Join(", ", fruttaInComune));
+        Console.WriteLine("Except - Frutta solo estiva: " + string.Join(", ", soloEstiva));
+        Console.WriteLine();
+    }
+}

--- a/Linq/TakeSkipExample.cs
+++ b/Linq/TakeSkipExample.cs
@@ -1,0 +1,16 @@
+public static class TakeSkipExample
+{
+    public static void Execute()
+    {
+        List<int> numeri = Enumerable.Range(1, 10).ToList();
+
+        IEnumerable<int> primiQuattro = numeri.Take(4);
+        IEnumerable<int> senzaPrimiTre = numeri.Skip(3);
+        IEnumerable<int> intervalloCentrale = numeri.Skip(2).Take(5);
+
+        Console.WriteLine("Take - Primi 4 numeri: " + string.Join(", ", primiQuattro));
+        Console.WriteLine("Skip - Numeri senza i primi 3: " + string.Join(", ", senzaPrimiTre));
+        Console.WriteLine("Combinazione Skip/Take - Dal 3° al 7° numero: " + string.Join(", ", intervalloCentrale));
+        Console.WriteLine();
+    }
+}


### PR DESCRIPTION
## Summary
- add a Take/Skip example demonstrating basic pagination operations on a numeric list
- add a set operations example covering Distinct, Union, Intersect, and Except on collections of fruit names
- update the LINQ program entry point to execute the new examples

## Testing
- `dotnet run --project Linq/Linq.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68cd161c69c08324a89bdb7339a988f1