### PR TITLE
Add observer pattern example to PatternEDatabase

### DIFF
--- a/PatternEDatabase/24 Observer/ConsoleWeatherObserver.cs
+++ b/PatternEDatabase/24 Observer/ConsoleWeatherObserver.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace PatternEDatabase.Observer;
+
+/// <summary>
+/// Osservatore concreto che stampa su console gli aggiornamenti ricevuti.
+/// </summary>
+public sealed class ConsoleWeatherObserver : IWeatherObserver
+{
+    private readonly string _name;
+
+    public ConsoleWeatherObserver(string name)
+    {
+        _name = string.IsNullOrWhiteSpace(name) ? "Display" : name.Trim();
+    }
+
+    public void Update(WeatherReading reading)
+    {
+        Console.WriteLine($"[{_name}] Temperatura: {reading.TemperatureCelsius:F1} °C - Umidità: {reading.HumidityPercentage}% - Pressione: {reading.PressureHpa:F1} hPa");
+    }
+}

--- a/PatternEDatabase/24 Observer/IWeatherObserver.cs
+++ b/PatternEDatabase/24 Observer/IWeatherObserver.cs
@@ -1,0 +1,9 @@
+namespace PatternEDatabase.Observer;
+
+/// <summary>
+/// Contratto per gli oggetti che vogliono ricevere aggiornamenti dalla stazione meteo.
+/// </summary>
+public interface IWeatherObserver
+{
+    void Update(WeatherReading reading);
+}

--- a/PatternEDatabase/24 Observer/ObserverPatternDemo.cs
+++ b/PatternEDatabase/24 Observer/ObserverPatternDemo.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace PatternEDatabase.Observer;
+
+/// <summary>
+/// Dimostrazione concreta del pattern Observer applicato ad una stazione meteorologica.
+/// </summary>
+public static class ObserverPatternDemo
+{
+    public static void Run()
+    {
+        Console.WriteLine("=== Observer Pattern: Stazione Meteo ===");
+
+        var station = new WeatherStation();
+
+        var kitchenDisplay = new ConsoleWeatherObserver("Display cucina");
+        var mobileAppDisplay = new ConsoleWeatherObserver("App meteo");
+        var statisticsObserver = new StatisticsWeatherObserver();
+
+        using var kitchenSubscription = station.Subscribe(kitchenDisplay);
+        var mobileSubscription = station.Subscribe(mobileAppDisplay);
+        using var statisticsSubscription = station.Subscribe(statisticsObserver);
+
+        station.UpdateMeasurements(22.4m, 58, 1013.5m);
+        station.UpdateMeasurements(23.1m, 55, 1012.8m);
+        station.UpdateMeasurements(24.6m, 52, 1011.9m);
+
+        Console.WriteLine("--- L'app meteo si disiscrive dagli aggiornamenti ---");
+        mobileSubscription.Dispose();
+
+        station.UpdateMeasurements(19.8m, 68, 1015.2m);
+
+        Console.WriteLine();
+        Console.WriteLine(statisticsObserver.BuildReport());
+        Console.WriteLine();
+    }
+}

--- a/PatternEDatabase/24 Observer/StatisticsWeatherObserver.cs
+++ b/PatternEDatabase/24 Observer/StatisticsWeatherObserver.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace PatternEDatabase.Observer;
+
+/// <summary>
+/// Osservatore che accumula le letture e produce un report riassuntivo.
+/// </summary>
+public sealed class StatisticsWeatherObserver : IWeatherObserver
+{
+    private readonly List<WeatherReading> _readings = new();
+
+    public void Update(WeatherReading reading)
+    {
+        _readings.Add(reading);
+    }
+
+    public string BuildReport()
+    {
+        if (_readings.Count == 0)
+        {
+            return "Statistiche non disponibili: nessun dato ricevuto.";
+        }
+
+        var averageTemperature = _readings.Average(r => r.TemperatureCelsius);
+        var minTemperature = _readings.Min(r => r.TemperatureCelsius);
+        var maxTemperature = _readings.Max(r => r.TemperatureCelsius);
+        var averageHumidity = _readings.Average(r => r.HumidityPercentage);
+        var lastPressure = _readings[^1].PressureHpa;
+
+        var builder = new StringBuilder();
+        builder.AppendLine("Statistiche della stazione meteo:");
+        builder.AppendLine($" - Temperatura media: {averageTemperature:F1} °C (min {minTemperature:F1} °C, max {maxTemperature:F1} °C)");
+        builder.AppendLine($" - Umidità media: {averageHumidity:F0}%");
+        builder.Append($" - Ultima pressione rilevata: {lastPressure:F1} hPa");
+
+        return builder.ToString();
+    }
+}

--- a/PatternEDatabase/24 Observer/WeatherReading.cs
+++ b/PatternEDatabase/24 Observer/WeatherReading.cs
@@ -1,0 +1,9 @@
+namespace PatternEDatabase.Observer;
+
+/// <summary>
+/// Rappresenta un singolo rilievo ambientale della stazione meteo.
+/// </summary>
+/// <param name="TemperatureCelsius">Temperatura in gradi centigradi.</param>
+/// <param name="HumidityPercentage">Percentuale di umidità relativa.</param>
+/// <param name="PressureHpa">Pressione atmosferica in hPa.</param>
+public readonly record struct WeatherReading(decimal TemperatureCelsius, int HumidityPercentage, decimal PressureHpa);

--- a/PatternEDatabase/24 Observer/WeatherStation.cs
+++ b/PatternEDatabase/24 Observer/WeatherStation.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+
+namespace PatternEDatabase.Observer;
+
+/// <summary>
+/// Soggetto osservato: mantiene lo stato meteo ed avvisa tutti gli osservatori registrati.
+/// </summary>
+public sealed class WeatherStation
+{
+    private readonly List<IWeatherObserver> _observers = new();
+    private WeatherReading? _lastReading;
+
+    /// <summary>
+    /// Registra un nuovo osservatore e restituisce un oggetto IDisposable per annullare l'iscrizione.
+    /// </summary>
+    public IDisposable Subscribe(IWeatherObserver observer)
+    {
+        ArgumentNullException.ThrowIfNull(observer);
+
+        if (!_observers.Contains(observer))
+        {
+            _observers.Add(observer);
+
+            if (_lastReading is WeatherReading lastReading)
+            {
+                observer.Update(lastReading);
+            }
+        }
+
+        return new Subscription(_observers, observer);
+    }
+
+    /// <summary>
+    /// Aggiorna le letture e notifica gli osservatori.
+    /// </summary>
+    public void UpdateMeasurements(decimal temperatureCelsius, int humidityPercentage, decimal pressureHpa)
+    {
+        Publish(new WeatherReading(temperatureCelsius, humidityPercentage, pressureHpa));
+    }
+
+    /// <summary>
+    /// Pubblica una lettura già costruita.
+    /// </summary>
+    public void Publish(WeatherReading reading)
+    {
+        _lastReading = reading;
+
+        // Copiamo l'elenco per evitare problemi se un osservatore si disiscrive durante la notifica.
+        foreach (var observer in _observers.ToArray())
+        {
+            observer.Update(reading);
+        }
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private readonly List<IWeatherObserver> _observers;
+        private IWeatherObserver? _observer;
+
+        public Subscription(List<IWeatherObserver> observers, IWeatherObserver observer)
+        {
+            _observers = observers;
+            _observer = observer;
+        }
+
+        public void Dispose()
+        {
+            if (_observer is { } existingObserver)
+            {
+                _observers.Remove(existingObserver);
+                _observer = null;
+            }
+        }
+    }
+}

--- a/PatternEDatabase/Program.cs
+++ b/PatternEDatabase/Program.cs
@@ -1,3 +1,5 @@
+using PatternEDatabase.Observer;
+
 namespace PatternEDatabaseApp;
 
 public static class Program
@@ -8,7 +10,11 @@ public static class Program
         Console.WriteLine(" - 21 MVVC");
         Console.WriteLine(" - 22 SQLite");
         Console.WriteLine(" - 23 Singleton");
+        Console.WriteLine(" - 24 Observer");
         Console.WriteLine();
         Console.WriteLine("Verifica ogni cartella per esempi completi e note teoriche.");
+        Console.WriteLine();
+
+        ObserverPatternDemo.Run();
     }
 }


### PR DESCRIPTION
## Summary
- add a weather-station based example of the Observer design pattern
- expose concrete observers, the subject implementation, and a runnable demo
- update the project entry point to list and execute the new sample

## Testing
- ⚠️ dotnet build PatternEDatabase/PatternEDatabase.csproj *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d915be81708324ab69694ea63e60a6