### PR TITLE
Add interactive demos for MVVC, SQLite, and Singleton patterns

### DIFF
--- a/PatternEDatabase/21 MVVC/MvvcDemo.cs
+++ b/PatternEDatabase/21 MVVC/MvvcDemo.cs
@@ -1,0 +1,19 @@
+using System;
+
+/// <summary>
+/// Dimostrazione minimale per l'architettura Model-View-ViewModel-Controller.
+/// </summary>
+public static class MvvcDemo
+{
+    public static void Run()
+    {
+        Console.WriteLine("=== MVVC Demo ===");
+        Console.WriteLine("Il controller orchestrerà l'interazione con l'utente tramite la console.\n");
+
+        var viewModel = new UserViewModel();
+        var view = new ConsoleView();
+        var controller = new UserController(viewModel, view);
+
+        controller.Run();
+    }
+}

--- a/PatternEDatabase/22 SQLite/Program.cs
+++ b/PatternEDatabase/22 SQLite/Program.cs
@@ -1,44 +1,73 @@
 using System;
 using System.Data.SQLite;
+using System.IO;
 
 namespace SQLiteExamples;
 
-/*class Program
+public static class SQLiteDemo
 {
-    static void Main()
+    public static void Run()
     {
-        var dbPath = "example.db";
-        if (File.Exists(dbPath))
+        var tempFile = Path.Combine(Path.GetTempPath(), $"sqlite-demo-{Guid.NewGuid():N}.db");
+        Console.WriteLine("=== SQLite Demo ===");
+        Console.WriteLine($"Database temporaneo: {tempFile}");
+
+        try
         {
-            File.Delete(dbPath);
+            if (File.Exists(tempFile))
+            {
+                File.Delete(tempFile);
+            }
+
+            SQLiteConnection.CreateFile(tempFile);
+            using var connection = new SQLiteConnection($"Data Source={tempFile};Version=3;");
+            connection.Open();
+
+            using var create = new SQLiteCommand(
+                "CREATE TABLE people (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, age INTEGER)",
+                connection);
+            create.ExecuteNonQuery();
+
+            using var insert = new SQLiteCommand(
+                "INSERT INTO people (name, age) VALUES (@name, @age)",
+                connection);
+            insert.Parameters.Add(new SQLiteParameter("@name"));
+            insert.Parameters.Add(new SQLiteParameter("@age"));
+
+            insert.Parameters["@name"].Value = "Alice";
+            insert.Parameters["@age"].Value = 30;
+            insert.ExecuteNonQuery();
+
+            insert.Parameters["@name"].Value = "Bob";
+            insert.Parameters["@age"].Value = 25;
+            insert.ExecuteNonQuery();
+
+            using var query = new SQLiteCommand("SELECT id, name, age FROM people", connection);
+            using var reader = query.ExecuteReader();
+            while (reader.Read())
+            {
+                Console.WriteLine($"{reader["id"]}: {reader["name"]} ({reader["age"]})");
+            }
         }
-
-        SQLiteConnection.CreateFile(dbPath);
-        using var connection = new SQLiteConnection($"Data Source={dbPath};Version=3;");
-        connection.Open();
-
-        using var create = new SQLiteCommand("CREATE TABLE people (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, age INTEGER)", connection);
-        create.ExecuteNonQuery();
-
-        using var insert = new SQLiteCommand("INSERT INTO people (name, age) VALUES (@name, @age)", connection);
-        insert.Parameters.Add(new SQLiteParameter("@name"));
-        insert.Parameters.Add(new SQLiteParameter("@age"));
-
-        // "INSERT INTO people (name, age) VALUES (Alice, 30)"
-        insert.Parameters["@name"].Value = "Alice";
-        insert.Parameters["@age"].Value = 30;
-        insert.ExecuteNonQuery();
-
-        // "INSERT INTO people (name, age) VALUES (Bob, 25)"
-        insert.Parameters["@name"].Value = "Bob";
-        insert.Parameters["@age"].Value = 25;
-        insert.ExecuteNonQuery();
-
-        using var query = new SQLiteCommand("SELECT id, name, age FROM people", connection);
-        using var reader = query.ExecuteReader();
-        while (reader.Read())
+        catch (Exception ex)
         {
-            Console.WriteLine($"{reader["id"]}: {reader["name"]} ({reader["age"]})");
+            Console.WriteLine("Si è verificato un errore durante l'esecuzione della demo SQLite.");
+            Console.WriteLine(ex.Message);
+        }
+        finally
+        {
+            try
+            {
+                if (File.Exists(tempFile))
+                {
+                    File.Delete(tempFile);
+                }
+            }
+            catch (Exception cleanupEx)
+            {
+                Console.WriteLine("Impossibile eliminare il file temporaneo creato per la demo.");
+                Console.WriteLine(cleanupEx.Message);
+            }
         }
     }
-}*/
+}

--- a/PatternEDatabase/23 Singleton/DatabaseManager.cs
+++ b/PatternEDatabase/23 Singleton/DatabaseManager.cs
@@ -1,30 +1,54 @@
+using System;
+
 public class DatabaseManager : GenericSingleton<DatabaseManager>
 {
-    // private Db _db;
+    private bool _isConnected;
+    private bool _dataLoaded;
 
     protected override void OnPostAwake()
     {
-        // Eseguire qualcosa dopo la PRIMA istanziazione.
+        Console.WriteLine("[DatabaseManager] Istanza creata.");
     }
 
     protected override void OnPostDestroy()
     {
-        // Salvare le impostazioni
-        // Disconnettersi dal db
-    }
-
-    public void Save()
-    {
-
+        Console.WriteLine("[DatabaseManager] Istanza distrutta.");
+        _isConnected = false;
+        _dataLoaded = false;
     }
 
     public void Connect()
     {
+        if (_isConnected)
+        {
+            Console.WriteLine("[DatabaseManager] Connessione già attiva.");
+            return;
+        }
 
+        Console.WriteLine("[DatabaseManager] Connessione al database...");
+        _isConnected = true;
     }
 
     public void Load()
     {
+        if (!_isConnected)
+        {
+            Console.WriteLine("[DatabaseManager] Impossibile caricare: nessuna connessione attiva.");
+            return;
+        }
 
+        Console.WriteLine("[DatabaseManager] Caricamento dei dati completato.");
+        _dataLoaded = true;
+    }
+
+    public void Save()
+    {
+        if (!_isConnected || !_dataLoaded)
+        {
+            Console.WriteLine("[DatabaseManager] Nulla da salvare: assicurarsi che la connessione sia attiva e i dati siano caricati.");
+            return;
+        }
+
+        Console.WriteLine("[DatabaseManager] Salvataggio delle modifiche eseguito.");
     }
 }

--- a/PatternEDatabase/23 Singleton/SingletonDemo.cs
+++ b/PatternEDatabase/23 Singleton/SingletonDemo.cs
@@ -1,0 +1,25 @@
+using System;
+
+public static class SingletonDemo
+{
+    public static void Run()
+    {
+        Console.WriteLine("=== Singleton Demo ===");
+
+        var manager = DatabaseManager.Instance;
+        manager.Connect();
+        manager.Load();
+        manager.Save();
+
+        Console.WriteLine();
+        Console.WriteLine("Recupero nuovamente l'istanza del DatabaseManager...");
+
+        var sameManager = DatabaseManager.Instance;
+        sameManager.Connect();
+        sameManager.Load();
+        sameManager.Save();
+
+        Console.WriteLine();
+        Console.WriteLine("La stessa istanza viene riutilizzata in tutte le chiamate.");
+    }
+}

--- a/PatternEDatabase/Program.cs
+++ b/PatternEDatabase/Program.cs
@@ -1,4 +1,6 @@
+using System;
 using PatternEDatabase.Observer;
+using SQLiteExamples;
 
 namespace PatternEDatabaseApp;
 
@@ -6,15 +8,75 @@ public static class Program
 {
     public static void Main(string[] args)
     {
-        Console.WriteLine("Pattern e accesso ai dati inclusi:");
-        Console.WriteLine(" - 21 MVVC");
-        Console.WriteLine(" - 22 SQLite");
-        Console.WriteLine(" - 23 Singleton");
-        Console.WriteLine(" - 24 Observer");
-        Console.WriteLine();
-        Console.WriteLine("Verifica ogni cartella per esempi completi e note teoriche.");
-        Console.WriteLine();
+        if (args.Length > 0)
+        {
+            if (!TryRunDemo(args[0]))
+            {
+                Console.WriteLine("Argomento non valido. Opzioni disponibili: mvvc, sqlite, singleton, observer.");
+            }
 
-        ObserverPatternDemo.Run();
+            return;
+        }
+
+        var running = true;
+        while (running)
+        {
+            Console.WriteLine("Pattern e accesso ai dati inclusi:");
+            Console.WriteLine(" 1. 21 MVVC");
+            Console.WriteLine(" 2. 22 SQLite");
+            Console.WriteLine(" 3. 23 Singleton");
+            Console.WriteLine(" 4. 24 Observer");
+            Console.WriteLine(" Q. Esci");
+            Console.WriteLine();
+            Console.Write("Seleziona un'opzione: ");
+
+            var choice = Console.ReadLine();
+            if (choice == null || choice.Trim().Equals("q", StringComparison.OrdinalIgnoreCase))
+            {
+                running = false;
+                continue;
+            }
+
+            if (!TryRunDemo(choice))
+            {
+                Console.WriteLine("Opzione non valida, riprova.\n");
+            }
+            else
+            {
+                Console.WriteLine();
+            }
+        }
+
+        Console.WriteLine("Chiusura del programma. A presto!");
+    }
+
+    private static bool TryRunDemo(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return false;
+        }
+
+        switch (input.Trim().ToLowerInvariant())
+        {
+            case "1":
+            case "mvvc":
+                MvvcDemo.Run();
+                return true;
+            case "2":
+            case "sqlite":
+                SQLiteDemo.Run();
+                return true;
+            case "3":
+            case "singleton":
+                SingletonDemo.Run();
+                return true;
+            case "4":
+            case "observer":
+                ObserverPatternDemo.Run();
+                return true;
+            default:
+                return false;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add an MVVC console demo that wires together the existing view, view model, and controller
- refactor the SQLite sample into a reusable demo that creates a temporary database with cleanup and error handling
- implement a concrete singleton demo and expose all demos through an interactive or argument-driven launcher

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d91acb2020832493de069c8550c0de