### PR TITLE
Add Command pattern demo

### DIFF
--- a/5 Pattern e Database/25 Command/CommandPatternDemo.cs
+++ b/5 Pattern e Database/25 Command/CommandPatternDemo.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace PatternEDatabase.Command;
+
+public static class CommandPatternDemo
+{
+    public static void Run()
+    {
+        Console.WriteLine("=== Pattern Command ===");
+        Console.WriteLine("Questo esempio dimostra come il Command disaccoppi invoker, comando e receiver.\n");
+
+        var luceSoggiorno = new Light("del soggiorno");
+        var accendiLuce = new LightOnCommand(luceSoggiorno);
+        var spegniLuce = new LightOffCommand(luceSoggiorno);
+
+        var telecomando = new RemoteControl();
+        telecomando.SetCommand("Luce soggiorno ON", accendiLuce);
+        telecomando.SetCommand("Luce soggiorno OFF", spegniLuce);
+
+        Console.WriteLine();
+        telecomando.PressButton("Luce soggiorno ON");
+        telecomando.PressButton("Luce soggiorno OFF");
+        telecomando.UndoLastCommand();
+        telecomando.UndoLastCommand();
+        telecomando.UndoLastCommand();
+    }
+}

--- a/5 Pattern e Database/25 Command/ICommand.cs
+++ b/5 Pattern e Database/25 Command/ICommand.cs
@@ -1,0 +1,8 @@
+namespace PatternEDatabase.Command;
+
+public interface ICommand
+{
+    void Execute();
+
+    void Undo();
+}

--- a/5 Pattern e Database/25 Command/Light.cs
+++ b/5 Pattern e Database/25 Command/Light.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace PatternEDatabase.Command;
+
+public class Light
+{
+    private readonly string _location;
+    private bool _isOn;
+
+    public Light(string location)
+    {
+        _location = location;
+    }
+
+    public void Accendi()
+    {
+        if (_isOn)
+        {
+            Console.WriteLine($"La luce {_location} è già accesa.");
+            return;
+        }
+
+        _isOn = true;
+        Console.WriteLine($"La luce {_location} si accende.");
+    }
+
+    public void Spegni()
+    {
+        if (!_isOn)
+        {
+            Console.WriteLine($"La luce {_location} è già spenta.");
+            return;
+        }
+
+        _isOn = false;
+        Console.WriteLine($"La luce {_location} si spegne.");
+    }
+}

--- a/5 Pattern e Database/25 Command/LightOffCommand.cs
+++ b/5 Pattern e Database/25 Command/LightOffCommand.cs
@@ -1,0 +1,21 @@
+namespace PatternEDatabase.Command;
+
+public class LightOffCommand : ICommand
+{
+    private readonly Light _light;
+
+    public LightOffCommand(Light light)
+    {
+        _light = light;
+    }
+
+    public void Execute()
+    {
+        _light.Spegni();
+    }
+
+    public void Undo()
+    {
+        _light.Accendi();
+    }
+}

--- a/5 Pattern e Database/25 Command/LightOnCommand.cs
+++ b/5 Pattern e Database/25 Command/LightOnCommand.cs
@@ -1,0 +1,21 @@
+namespace PatternEDatabase.Command;
+
+public class LightOnCommand : ICommand
+{
+    private readonly Light _light;
+
+    public LightOnCommand(Light light)
+    {
+        _light = light;
+    }
+
+    public void Execute()
+    {
+        _light.Accendi();
+    }
+
+    public void Undo()
+    {
+        _light.Spegni();
+    }
+}

--- a/5 Pattern e Database/25 Command/RemoteControl.cs
+++ b/5 Pattern e Database/25 Command/RemoteControl.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+
+namespace PatternEDatabase.Command;
+
+public class RemoteControl
+{
+    private readonly Dictionary<string, ICommand> _commands = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Stack<(string Name, ICommand Command)> _history = new();
+
+    public void SetCommand(string label, ICommand command)
+    {
+        _commands[label] = command;
+        Console.WriteLine($"[Config] Comando '{label}' registrato nel telecomando.");
+    }
+
+    public void PressButton(string label)
+    {
+        if (!_commands.TryGetValue(label, out var command))
+        {
+            Console.WriteLine($"[Remote] Nessun comando configurato per '{label}'.");
+            return;
+        }
+
+        Console.WriteLine($"[Remote] Esecuzione del comando '{label}'.");
+        command.Execute();
+        _history.Push((label, command));
+    }
+
+    public void UndoLastCommand()
+    {
+        if (_history.Count == 0)
+        {
+            Console.WriteLine("[Remote] Nessun comando da annullare.");
+            return;
+        }
+
+        var (label, command) = _history.Pop();
+        Console.WriteLine($"[Remote] Annullamento dell'ultimo comando '{label}'.");
+        command.Undo();
+    }
+}

--- a/5 Pattern e Database/Program.cs
+++ b/5 Pattern e Database/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using PatternEDatabase.Command;
 using PatternEDatabase.Observer;
 using PatternEDatabase.State;
 using SQLiteExamples;
@@ -13,7 +14,7 @@ public static class Program
         {
             if (!TryRunDemo(args[0]))
             {
-                Console.WriteLine("Argomento non valido. Opzioni disponibili: mvvc, sqlite, singleton, observer, state.");
+                Console.WriteLine("Argomento non valido. Opzioni disponibili: mvvc, sqlite, singleton, observer, command, state.");
             }
 
             return;
@@ -27,7 +28,8 @@ public static class Program
             Console.WriteLine(" 2. 22 SQLite");
             Console.WriteLine(" 3. 23 Singleton");
             Console.WriteLine(" 4. 24 Observer");
-            Console.WriteLine(" 5. 25 State");
+            Console.WriteLine(" 5. 25 Command");
+            Console.WriteLine(" 6. 25 State");
             Console.WriteLine(" Q. Esci");
             Console.WriteLine();
             Console.Write("Seleziona un'opzione: ");
@@ -78,6 +80,10 @@ public static class Program
                 ObserverPatternDemo.Run();
                 return true;
             case "5":
+            case "command":
+                CommandPatternDemo.Run();
+                return true;
+            case "6":
             case "state":
                 StatePatternDemo.Run();
                 return true;

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Raccolta di materiale didattico per il corso di C# e MAUI. Ogni macro-area del p
 - **ProgrammazioneOggetti** (`ProgrammazioneOggetti/`): classi, proprietà, interfacce, ereditarietà ed eccezioni.
 - **StruttureEDati** (`StruttureEDati/`): esempi su generics, collezioni e gestione di file.
 - **ProgrammazioneAvanzata** (`ProgrammazioneAvanzata/`): delegati, eventi e programmazione asincrona.
-- **PatternEDatabase** (`PatternEDatabase/`): MVVM, accesso SQLite e pattern Singleton.
+- **PatternEDatabase** (`PatternEDatabase/`): MVVM, accesso SQLite e pattern di progettazione (Singleton, Observer, State, Command).
 - **ProgettiExtra** (`ProgettiExtra/`): esercizi e mini-progetti di approfondimento.
 - **Linq** (`Linq/`): esempi dedicati alle principali operazioni LINQ.
 


### PR DESCRIPTION
## Summary
- add a new Command pattern example with light commands and a remote control invoker
- extend the pattern menu to expose the new demo and update documentation to mention it

## Testing
- `dotnet build '5 Pattern e Database/PatternEDatabase.csproj'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d97e0544d08324a416b1ba5b5c9f78