### PR TITLE
Add Facade pattern example

### DIFF
--- a/5 Pattern e Database/27 Facade/AmbientLight.cs
+++ b/5 Pattern e Database/27 Facade/AmbientLight.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace PatternEDatabase.Facade;
+
+public class AmbientLight
+{
+    public void Dim(int level)
+    {
+        Console.WriteLine($"- Luci ambientali regolate al {level}%");
+    }
+
+    public void TurnOn()
+    {
+        Console.WriteLine("- Luci ambientali accese soffusamente");
+    }
+
+    public void TurnOff()
+    {
+        Console.WriteLine("- Luci ambientali spente");
+    }
+}

--- a/5 Pattern e Database/27 Facade/FacadePatternDemo.cs
+++ b/5 Pattern e Database/27 Facade/FacadePatternDemo.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace PatternEDatabase.Facade;
+
+public static class FacadePatternDemo
+{
+    public static void Run()
+    {
+        Console.WriteLine("=== Pattern Facade ===");
+        Console.WriteLine("Il Facade nasconde la complessità di un sottosistema dietro un'unica interfaccia semplice.\n");
+
+        var facade = new HomeTheaterFacade(
+            new StreamingService(),
+            new SurroundSoundSystem(),
+            new Projector(),
+            new AmbientLight());
+
+        facade.StartMovieNight("Ritorno al Futuro");
+        Console.WriteLine("Premi invio quando il film è terminato...");
+        Console.ReadLine();
+        facade.EndMovieNight();
+    }
+}

--- a/5 Pattern e Database/27 Facade/HomeTheaterFacade.cs
+++ b/5 Pattern e Database/27 Facade/HomeTheaterFacade.cs
@@ -1,0 +1,47 @@
+using System;
+
+namespace PatternEDatabase.Facade;
+
+public class HomeTheaterFacade
+{
+    private readonly StreamingService _streamingService;
+    private readonly SurroundSoundSystem _soundSystem;
+    private readonly Projector _projector;
+    private readonly AmbientLight _ambientLight;
+
+    public HomeTheaterFacade(
+        StreamingService streamingService,
+        SurroundSoundSystem soundSystem,
+        Projector projector,
+        AmbientLight ambientLight)
+    {
+        _streamingService = streamingService;
+        _soundSystem = soundSystem;
+        _projector = projector;
+        _ambientLight = ambientLight;
+    }
+
+    public void StartMovieNight(string movieTitle)
+    {
+        Console.WriteLine($"Preparazione della serata cinema per '{movieTitle}'...");
+        _ambientLight.Dim(20);
+        _ambientLight.TurnOn();
+        _projector.TurnOn();
+        _projector.SetInput("HDMI1");
+        _soundSystem.TurnOn();
+        _soundSystem.SetVolume(25);
+        _streamingService.Connect();
+        _streamingService.Play(movieTitle);
+        Console.WriteLine("Buona visione!\n");
+    }
+
+    public void EndMovieNight()
+    {
+        Console.WriteLine("Chiusura della serata cinema...");
+        _streamingService.Disconnect();
+        _soundSystem.TurnOff();
+        _projector.TurnOff();
+        _ambientLight.TurnOff();
+        Console.WriteLine("Serata conclusa. A presto!\n");
+    }
+}

--- a/5 Pattern e Database/27 Facade/Projector.cs
+++ b/5 Pattern e Database/27 Facade/Projector.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace PatternEDatabase.Facade;
+
+public class Projector
+{
+    public void TurnOn()
+    {
+        Console.WriteLine("- Proiettore acceso");
+    }
+
+    public void TurnOff()
+    {
+        Console.WriteLine("- Proiettore spento");
+    }
+
+    public void SetInput(string input)
+    {
+        Console.WriteLine($"- Proiettore impostato su sorgente {input}");
+    }
+}

--- a/5 Pattern e Database/27 Facade/StreamingService.cs
+++ b/5 Pattern e Database/27 Facade/StreamingService.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace PatternEDatabase.Facade;
+
+public class StreamingService
+{
+    public void Connect()
+    {
+        Console.WriteLine("- Servizio di streaming connesso");
+    }
+
+    public void Disconnect()
+    {
+        Console.WriteLine("- Servizio di streaming disconnesso");
+    }
+
+    public void Play(string movie)
+    {
+        Console.WriteLine($"- Riproduzione di '{movie}' avviata");
+    }
+}

--- a/5 Pattern e Database/27 Facade/SurroundSoundSystem.cs
+++ b/5 Pattern e Database/27 Facade/SurroundSoundSystem.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace PatternEDatabase.Facade;
+
+public class SurroundSoundSystem
+{
+    public void TurnOn()
+    {
+        Console.WriteLine("- Impianto surround acceso");
+    }
+
+    public void TurnOff()
+    {
+        Console.WriteLine("- Impianto surround spento");
+    }
+
+    public void SetVolume(int level)
+    {
+        Console.WriteLine($"- Volume impostato a {level}");
+    }
+}

--- a/5 Pattern e Database/Program.cs
+++ b/5 Pattern e Database/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using PatternEDatabase.Builder;
 using PatternEDatabase.Command;
+using PatternEDatabase.Facade;
 using PatternEDatabase.Factory;
 using PatternEDatabase.Observer;
 using PatternEDatabase.State;
@@ -16,7 +17,7 @@ public static class Program
         {
             if (!TryRunDemo(args[0]))
             {
-                Console.WriteLine("Argomento non valido. Opzioni disponibili: mvvc, sqlite, singleton, observer, command, state, builder.");
+                Console.WriteLine("Argomento non valido. Opzioni disponibili: mvvc, sqlite, singleton, observer, command, state, builder, factory, facade.");
             }
 
             return;
@@ -34,6 +35,7 @@ public static class Program
             Console.WriteLine(" 6. State");
             Console.WriteLine(" 7. Builder");
             Console.WriteLine(" 8. Factory Method / Abstract Factory");
+            Console.WriteLine(" 9. Facade");
             Console.WriteLine(" Q. Esci");
             Console.WriteLine();
             Console.Write("Seleziona un'opzione: ");
@@ -94,10 +96,17 @@ public static class Program
             case "7":
             case "builder":
                 BuilderPatternDemo.Run();
+                return true;
             case "factory":
             case "factory method":
             case "abstract factory":
                 FactoryPatternDemo.Run();
+                return true;
+            case "8":
+                goto case "factory";
+            case "9":
+            case "facade":
+                FacadePatternDemo.Run();
                 return true;
             default:
                 return false;


### PR DESCRIPTION
## Summary
- add a home theater Facade demo with subsystem components and a facade orchestrator
- register the Facade demo in the pattern launcher menu and CLI argument handling

## Testing
- not run (dotnet CLI non disponibile nell'ambiente)

------
https://chatgpt.com/codex/tasks/task_e_68e3baf0cfac8324889a23b331dcce42