### PR TITLE
Add adapter pattern example

### DIFF
--- a/5 Pattern e Database/31 Adapter/AdapterPatternDemo.cs
+++ b/5 Pattern e Database/31 Adapter/AdapterPatternDemo.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace PatternEDatabase.Adapter;
+
+public static class AdapterPatternDemo
+{
+    public static void Run()
+    {
+        Console.WriteLine("Esempio Adapter: uniformiamo l'invio di notifiche.\n");
+
+        INotificationService email = new EmailNotificationService();
+        INotificationService sms = new SmsNotificationAdapter(new LegacySmsSender());
+
+        InviaPromemoria(email, "alice@example.com");
+        Console.WriteLine();
+        InviaPromemoria(sms, "+39 123 456 7890");
+
+        Console.WriteLine("\nGrazie all'Adapter possiamo riutilizzare servizi esistenti senza modificarli.");
+    }
+
+    private static void InviaPromemoria(INotificationService notificationService, string destinatario)
+    {
+        Console.WriteLine($"Invio promemoria a {destinatario}...");
+        notificationService.Send(destinatario, "Domani riunione alle 9:00.");
+    }
+}

--- a/5 Pattern e Database/31 Adapter/EmailNotificationService.cs
+++ b/5 Pattern e Database/31 Adapter/EmailNotificationService.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace PatternEDatabase.Adapter;
+
+public class EmailNotificationService : INotificationService
+{
+    public void Send(string destinatario, string messaggio)
+    {
+        Console.WriteLine($"Email inviata a {destinatario}: {messaggio}");
+    }
+}

--- a/5 Pattern e Database/31 Adapter/INotificationService.cs
+++ b/5 Pattern e Database/31 Adapter/INotificationService.cs
@@ -1,0 +1,6 @@
+namespace PatternEDatabase.Adapter;
+
+public interface INotificationService
+{
+    void Send(string destinatario, string messaggio);
+}

--- a/5 Pattern e Database/31 Adapter/LegacySmsSender.cs
+++ b/5 Pattern e Database/31 Adapter/LegacySmsSender.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace PatternEDatabase.Adapter;
+
+public class LegacySmsSender
+{
+    public void SendSms(string phoneNumber, string text)
+    {
+        Console.WriteLine($"SMS inviato al numero {phoneNumber}: {text}");
+    }
+}

--- a/5 Pattern e Database/31 Adapter/SmsNotificationAdapter.cs
+++ b/5 Pattern e Database/31 Adapter/SmsNotificationAdapter.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace PatternEDatabase.Adapter;
+
+public class SmsNotificationAdapter : INotificationService
+{
+    private readonly LegacySmsSender _smsSender;
+
+    public SmsNotificationAdapter(LegacySmsSender smsSender)
+    {
+        _smsSender = smsSender ?? throw new ArgumentNullException(nameof(smsSender));
+    }
+
+    public void Send(string destinatario, string messaggio)
+    {
+        Console.WriteLine("Adapter: converto la richiesta generica in un SMS specifico.");
+        _smsSender.SendSms(destinatario, messaggio);
+    }
+}

--- a/5 Pattern e Database/Program.cs
+++ b/5 Pattern e Database/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using PatternEDatabase.Adapter;
 using PatternEDatabase.Bridge;
 using PatternEDatabase.Builder;
 using PatternEDatabase.ChainOfResponsibility;
@@ -20,7 +21,7 @@ public static class Program
         {
             if (!TryRunDemo(args[0]))
             {
-                Console.WriteLine("Argomento non valido. Opzioni disponibili: mvvc, sqlite, singleton, observer, command, state, builder, factory, facade, decorator, chain, bridge.");
+                Console.WriteLine("Argomento non valido. Opzioni disponibili: mvvc, sqlite, singleton, observer, command, state, builder, factory, facade, decorator, chain, bridge, adapter.");
             }
 
             return;
@@ -42,6 +43,7 @@ public static class Program
             Console.WriteLine("10. Decorator");
             Console.WriteLine("11. Chain of Responsibility");
             Console.WriteLine("12. Bridge");
+            Console.WriteLine("13. Adapter");
             Console.WriteLine(" Q. Esci");
             Console.WriteLine();
             Console.Write("Seleziona un'opzione: ");
@@ -126,6 +128,10 @@ public static class Program
             case "12":
             case "bridge":
                 BridgePatternDemo.Run();
+                return true;
+            case "13":
+            case "adapter":
+                AdapterPatternDemo.Run();
                 return true;
             default:
                 return false;


### PR DESCRIPTION
## Summary
- add a notification-based example that demonstrates the Adapter pattern
- integrate the new demo into the console menu and CLI argument handling

## Testing
- dotnet build (fails: dotnet command not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68fdeb3ba6508324af8f156b140b526a