### PR TITLE
Add proxy pattern example

### DIFF
--- a/5 Pattern e Database/34 Proxy/CachedVideoServiceProxy.cs
+++ b/5 Pattern e Database/34 Proxy/CachedVideoServiceProxy.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+
+namespace PatternEDatabase.Proxy;
+
+public class CachedVideoServiceProxy : IVideoService
+{
+    private readonly IVideoService _videoService;
+    private readonly Dictionary<string, string> _cache = new(StringComparer.OrdinalIgnoreCase);
+
+    public CachedVideoServiceProxy(IVideoService videoService)
+    {
+        _videoService = videoService;
+    }
+
+    public string GetVideo(string titolo)
+    {
+        if (_cache.TryGetValue(titolo, out var contenuto))
+        {
+            Console.WriteLine($"Proxy: video \"{titolo}\" trovato in cache.");
+            return contenuto;
+        }
+
+        Console.WriteLine($"Proxy: video \"{titolo}\" non in cache, delego al servizio reale.");
+        contenuto = _videoService.GetVideo(titolo);
+        _cache[titolo] = contenuto;
+        return contenuto;
+    }
+}

--- a/5 Pattern e Database/34 Proxy/IVideoService.cs
+++ b/5 Pattern e Database/34 Proxy/IVideoService.cs
@@ -1,0 +1,6 @@
+namespace PatternEDatabase.Proxy;
+
+public interface IVideoService
+{
+    string GetVideo(string titolo);
+}

--- a/5 Pattern e Database/34 Proxy/ProxyPatternDemo.cs
+++ b/5 Pattern e Database/34 Proxy/ProxyPatternDemo.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace PatternEDatabase.Proxy;
+
+public static class ProxyPatternDemo
+{
+    public static void Run()
+    {
+        Console.WriteLine("*** Proxy Pattern: Servizio di streaming video ***\n");
+
+        IVideoService servizioReale = new VideoService();
+        IVideoService proxy = new CachedVideoServiceProxy(servizioReale);
+
+        RiproduciVideo(proxy, "Gita in montagna");
+        RiproduciVideo(proxy, "Gita in montagna");
+        RiproduciVideo(proxy, "Corso di cucina");
+    }
+
+    private static void RiproduciVideo(IVideoService servizio, string titolo)
+    {
+        Console.WriteLine($"Richiesta del video: {titolo}");
+        var contenuto = servizio.GetVideo(titolo);
+        Console.WriteLine($"-> Risultato: {contenuto}\n");
+    }
+}

--- a/5 Pattern e Database/34 Proxy/VideoService.cs
+++ b/5 Pattern e Database/34 Proxy/VideoService.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace PatternEDatabase.Proxy;
+
+public class VideoService : IVideoService
+{
+    public string GetVideo(string titolo)
+    {
+        Console.WriteLine($"Scaricamento del video \"{titolo}\" dal server...");
+        return $"Contenuto video di {titolo}";
+    }
+}

--- a/5 Pattern e Database/Program.cs
+++ b/5 Pattern e Database/Program.cs
@@ -11,6 +11,7 @@ using PatternEDatabase.Factory;
 using PatternEDatabase.Observer;
 using PatternEDatabase.Flyweight;
 using PatternEDatabase.State;
+using PatternEDatabase.Proxy;
 using SQLiteExamples;
 
 namespace PatternEDatabaseApp;
@@ -23,7 +24,7 @@ public static class Program
         {
             if (!TryRunDemo(args[0]))
             {
-                Console.WriteLine("Argomento non valido. Opzioni disponibili: mvvc, sqlite, singleton, observer, command, state, builder, factory, facade, decorator, chain, bridge, adapter, composite, flyweight.");
+                Console.WriteLine("Argomento non valido. Opzioni disponibili: mvvc, sqlite, singleton, observer, command, state, builder, factory, facade, decorator, chain, bridge, adapter, composite, flyweight, proxy.");
             }
 
             return;
@@ -48,6 +49,7 @@ public static class Program
             Console.WriteLine("13. Adapter");
             Console.WriteLine("14. Composite");
             Console.WriteLine("15. Flyweight");
+            Console.WriteLine("16. Proxy");
             Console.WriteLine(" Q. Esci");
             Console.WriteLine();
             Console.Write("Seleziona un'opzione: ");
@@ -144,6 +146,10 @@ public static class Program
             case "15":
             case "flyweight":
                 FlyweightPatternDemo.Run();
+                return true;
+            case "16":
+            case "proxy":
+                ProxyPatternDemo.Run();
                 return true;
             default:
                 return false;


### PR DESCRIPTION
## Summary
- add a simple video streaming example to demonstrate the Proxy pattern with caching
- integrate the new proxy demo into the console menu and CLI error message

## Testing
- `dotnet build 5 Pattern e Database/PatternEDatabase.csproj` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fdf14cca648324b365f35ba56cf309