### PR TITLE
Fix stack span builder constructor

### DIFF
--- a/4 Programmazione Avanzata/18 MemoryManagement/StackAlloc/StackAllocExamples.cs
+++ b/4 Programmazione Avanzata/18 MemoryManagement/StackAlloc/StackAllocExamples.cs
@@ -9,7 +9,7 @@ public ref struct StackSpanBuilder
     private Span<char> _buffer;
     private int _written;
 
-    public StackSpanBuilder(scoped Span<char> buffer)
+    public StackSpanBuilder(Span<char> buffer)
     {
         _buffer = buffer;
         _written = 0;


### PR DESCRIPTION
## Summary
- adjust StackSpanBuilder constructor to accept a standard Span<char> so the buffer can be stored safely

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ffa1457564832497f25990652add68