### PR TITLE
Add MVP counter demo to pattern module

### DIFF
--- a/5 Pattern e Database/35 MVP/ConsoleCounterView.cs
+++ b/5 Pattern e Database/35 MVP/ConsoleCounterView.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace PatternEDatabase.Mvp;
+
+/// <summary>
+/// Implementazione console della vista per il pattern MVP.
+/// </summary>
+public class ConsoleCounterView : ICounterView
+{
+    public void ShowWelcome()
+    {
+        Console.WriteLine("=== MVP Demo ===");
+        Console.WriteLine("Questo esempio mostra come Controller e View collaborino sul Model.\n");
+        Console.WriteLine("Comandi disponibili: ");
+        Console.WriteLine("  [i]ncrementa  |  [d]ecrementa  |  [r]eset  |  [q]uit");
+    }
+
+    public void ShowValue(int value)
+    {
+        Console.WriteLine($"Valore corrente del contatore: {value}");
+    }
+
+    public void ShowUnknownCommand(string command)
+    {
+        Console.WriteLine($"Comando '{command}' non riconosciuto. Riprova.");
+    }
+
+    public string? ReadCommand()
+    {
+        Console.Write("Seleziona un comando: ");
+        return Console.ReadLine();
+    }
+
+    public void ShowGoodbye()
+    {
+        Console.WriteLine("\nChiusura della demo MVP.");
+    }
+}

--- a/5 Pattern e Database/35 MVP/CounterController.cs
+++ b/5 Pattern e Database/35 MVP/CounterController.cs
@@ -1,0 +1,73 @@
+using System;
+
+namespace PatternEDatabase.Mvp;
+
+/// <summary>
+/// Controller che coordina il modello e la vista secondo l'architettura MVP.
+/// </summary>
+public class CounterController
+{
+    private readonly CounterModel _model;
+    private readonly ICounterView _view;
+    private bool _isRunning;
+
+    public CounterController(CounterModel model, ICounterView view)
+    {
+        _model = model;
+        _view = view;
+        _model.CounterChanged += OnCounterChanged;
+    }
+
+    public void Run()
+    {
+        _isRunning = true;
+        _view.ShowWelcome();
+        _view.ShowValue(_model.Value);
+
+        while (_isRunning)
+        {
+            var command = _view.ReadCommand();
+            if (command is null)
+            {
+                continue;
+            }
+
+            HandleCommand(command.Trim().ToLowerInvariant());
+        }
+
+        _view.ShowGoodbye();
+    }
+
+    private void HandleCommand(string command)
+    {
+        switch (command)
+        {
+            case "i":
+            case "+":
+            case "incrementa":
+                _model.Increment();
+                break;
+            case "d":
+            case "-":
+            case "decrementa":
+                _model.Decrement();
+                break;
+            case "r":
+            case "reset":
+                _model.Reset();
+                break;
+            case "q":
+            case "esci":
+                _isRunning = false;
+                break;
+            default:
+                _view.ShowUnknownCommand(command);
+                break;
+        }
+    }
+
+    private void OnCounterChanged(int newValue)
+    {
+        _view.ShowValue(newValue);
+    }
+}

--- a/5 Pattern e Database/35 MVP/CounterModel.cs
+++ b/5 Pattern e Database/35 MVP/CounterModel.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace PatternEDatabase.Mvp;
+
+/// <summary>
+/// Modello semplice che mantiene il valore di un contatore e notifica i cambiamenti.
+/// </summary>
+public class CounterModel
+{
+    public event Action<int>? CounterChanged;
+
+    /// <summary>
+    /// Valore corrente del contatore.
+    /// </summary>
+    public int Value { get; private set; }
+
+    /// <summary>
+    /// Incrementa il contatore e notifica la vista.
+    /// </summary>
+    public void Increment()
+    {
+        Value++;
+        CounterChanged?.Invoke(Value);
+    }
+
+    /// <summary>
+    /// Decrementa il contatore e notifica la vista.
+    /// </summary>
+    public void Decrement()
+    {
+        Value--;
+        CounterChanged?.Invoke(Value);
+    }
+
+    /// <summary>
+    /// Reimposta il valore a zero e notifica la vista.
+    /// </summary>
+    public void Reset()
+    {
+        Value = 0;
+        CounterChanged?.Invoke(Value);
+    }
+}

--- a/5 Pattern e Database/35 MVP/ICounterView.cs
+++ b/5 Pattern e Database/35 MVP/ICounterView.cs
@@ -1,0 +1,13 @@
+namespace PatternEDatabase.Mvp;
+
+/// <summary>
+/// Contratto minimo per la vista del pattern MVP.
+/// </summary>
+public interface ICounterView
+{
+    void ShowWelcome();
+    void ShowValue(int value);
+    void ShowUnknownCommand(string command);
+    string? ReadCommand();
+    void ShowGoodbye();
+}

--- a/5 Pattern e Database/35 MVP/MvpDemo.cs
+++ b/5 Pattern e Database/35 MVP/MvpDemo.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace PatternEDatabase.Mvp;
+
+/// <summary>
+/// Punto di ingresso per la dimostrazione MVP.
+/// </summary>
+public static class MvpDemo
+{
+    public static void Run()
+    {
+        Console.WriteLine("Avvio della dimostrazione Model-View-Presenter.\n");
+
+        var model = new CounterModel();
+        var view = new ConsoleCounterView();
+        var controller = new CounterController(model, view);
+
+        controller.Run();
+    }
+}

--- a/5 Pattern e Database/Program.cs
+++ b/5 Pattern e Database/Program.cs
@@ -12,6 +12,7 @@ using PatternEDatabase.Observer;
 using PatternEDatabase.Flyweight;
 using PatternEDatabase.State;
 using PatternEDatabase.Proxy;
+using PatternEDatabase.Mvp;
 using SQLiteExamples;
 
 namespace PatternEDatabaseApp;
@@ -50,6 +51,7 @@ public static class Program
             Console.WriteLine("14. Composite");
             Console.WriteLine("15. Flyweight");
             Console.WriteLine("16. Proxy");
+            Console.WriteLine("17. MVP");
             Console.WriteLine(" Q. Esci");
             Console.WriteLine();
             Console.Write("Seleziona un'opzione: ");
@@ -150,6 +152,10 @@ public static class Program
             case "16":
             case "proxy":
                 ProxyPatternDemo.Run();
+                return true;
+            case "17":
+            case "mvp":
+                MvpDemo.Run();
                 return true;
             default:
                 return false;


### PR DESCRIPTION
## Summary
- add a console-based Model-View-Presenter example with counter model, view, and controller
- expose the new MVP demo from the pattern launcher menu

## Testing
- dotnet build "5 Pattern e Database/PatternEDatabase.csproj" *(fails: dotnet non disponibile nell'ambiente)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916f2873c1c8324a1bcfc1e45409720)