### PR TITLE
Add iterator pattern playlist example

### DIFF
--- a/5 Pattern e Database/36 Iterator/IteratorPatternDemo.cs
+++ b/5 Pattern e Database/36 Iterator/IteratorPatternDemo.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace PatternEDatabase.Iterator;
+
+public static class IteratorPatternDemo
+{
+    public static void Run()
+    {
+        Console.WriteLine("Esempio Iterator: attraversiamo una playlist con un iteratore personalizzato.\n");
+
+        var playlist = new SongCollection();
+        playlist.Add(new Song("City Lights", "Aurora Lane", "Synthwave", 2020, false));
+        playlist.Add(new Song("Morning Breeze", "The Dunes", "Indie", 2018, true));
+        playlist.Add(new Song("Ocean Echoes", "Blue Horizon", "Ambient", 2021, false));
+        playlist.Add(new Song("Fireflies", "Nocturna", "Pop", 2019, true));
+
+        Console.WriteLine("Scorro tutti i brani con foreach (usa l'iteratore personalizzato):");
+        foreach (var song in playlist)
+        {
+            Console.WriteLine($"- {song}");
+        }
+
+        Console.WriteLine("\nScorro solo i preferiti con un secondo iteratore (IEnumerable):");
+        foreach (var song in playlist.Favorites())
+        {
+            Console.WriteLine($"★ {song}");
+        }
+
+        Console.WriteLine("\nGrazie all'Iterator possiamo nascondere i dettagli della struttura interna e creare più percorsi di scorrimento.");
+    }
+}

--- a/5 Pattern e Database/36 Iterator/Song.cs
+++ b/5 Pattern e Database/36 Iterator/Song.cs
@@ -1,0 +1,6 @@
+namespace PatternEDatabase.Iterator;
+
+public record Song(string Title, string Artist, string Genre, int Year, bool IsFavorite)
+{
+    public override string ToString() => $"{Title} - {Artist} ({Year}, {Genre})";
+}

--- a/5 Pattern e Database/36 Iterator/SongCollection.cs
+++ b/5 Pattern e Database/36 Iterator/SongCollection.cs
@@ -1,0 +1,63 @@
+using System.Collections;
+
+namespace PatternEDatabase.Iterator;
+
+public class SongCollection : IEnumerable<Song>
+{
+    private readonly List<Song> _songs = new();
+
+    public void Add(Song song) => _songs.Add(song);
+
+    public IEnumerator<Song> GetEnumerator() => new SongIterator(_songs);
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public IEnumerable<Song> Favorites()
+    {
+        foreach (var song in this)
+        {
+            if (song.IsFavorite)
+            {
+                yield return song;
+            }
+        }
+    }
+
+    private class SongIterator : IEnumerator<Song>
+    {
+        private readonly List<Song> _items;
+        private int _position = -1;
+
+        public SongIterator(List<Song> items)
+        {
+            _items = items;
+        }
+
+        public Song Current
+        {
+            get
+            {
+                if (_position < 0 || _position >= _items.Count)
+                {
+                    throw new InvalidOperationException("Iteratore in una posizione non valida.");
+                }
+
+                return _items[_position];
+            }
+        }
+
+        object IEnumerator.Current => Current;
+
+        public bool MoveNext()
+        {
+            _position++;
+            return _position < _items.Count;
+        }
+
+        public void Reset() => _position = -1;
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/5 Pattern e Database/Program.cs
+++ b/5 Pattern e Database/Program.cs
@@ -13,6 +13,7 @@ using PatternEDatabase.Flyweight;
 using PatternEDatabase.State;
 using PatternEDatabase.Proxy;
 using PatternEDatabase.Mvp;
+using PatternEDatabase.Iterator;
 using SQLiteExamples;
 
 namespace PatternEDatabaseApp;
@@ -25,7 +26,7 @@ public static class Program
         {
             if (!TryRunDemo(args[0]))
             {
-                Console.WriteLine("Argomento non valido. Opzioni disponibili: mvvc, sqlite, singleton, observer, command, state, builder, factory, facade, decorator, chain, bridge, adapter, composite, flyweight, proxy.");
+                Console.WriteLine("Argomento non valido. Opzioni disponibili: mvvc, sqlite, singleton, observer, command, state, builder, factory, facade, decorator, chain, bridge, adapter, composite, flyweight, proxy, mvp, iterator.");
             }
 
             return;
@@ -52,6 +53,7 @@ public static class Program
             Console.WriteLine("15. Flyweight");
             Console.WriteLine("16. Proxy");
             Console.WriteLine("17. MVP");
+            Console.WriteLine("18. Iterator");
             Console.WriteLine(" Q. Esci");
             Console.WriteLine();
             Console.Write("Seleziona un'opzione: ");
@@ -156,6 +158,10 @@ public static class Program
             case "17":
             case "mvp":
                 MvpDemo.Run();
+                return true;
+            case "18":
+            case "iterator":
+                IteratorPatternDemo.Run();
                 return true;
             default:
                 return false;


### PR DESCRIPTION
## Summary
- add an iterator pattern demo with a playlist of songs and custom iterators
- update the console menu to expose the new iterator example
- provide a reusable song collection with favorite filtering

## Testing
- `dotnet build` *(fails: dotnet CLI not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69490e89a1d08324a30e9f681bff23d4)