### PR TITLE
Aggiungi demo del pattern Prototype e integralo nel menu

### DIFF
--- a/5 Pattern e Database/37 Prototype/PrototypePatternDemo.cs
+++ b/5 Pattern e Database/37 Prototype/PrototypePatternDemo.cs
@@ -1,0 +1,67 @@
+using System.Text;
+
+namespace PatternEDatabase.Prototype;
+
+public static class PrototypePatternDemo
+{
+    public static void Run()
+    {
+        var baseReport = new ReportTemplate(
+            "Report settimanale",
+            new List<string>
+            {
+                "Riepilogo metriche",
+                "Task completati",
+                "Rischi e mitigazioni"
+            });
+
+        var reportPerVendite = baseReport.Clone();
+        reportPerVendite.Title = "Report vendite - Area Nord";
+        reportPerVendite.Sections.Add("Pipeline commerciale");
+
+        var reportPerSupporto = baseReport.Clone();
+        reportPerSupporto.Title = "Report supporto clienti";
+        reportPerSupporto.Sections[1] = "Ticket risolti";
+
+        Console.WriteLine("--- Prototype ---");
+        Console.WriteLine(baseReport.Describe());
+        Console.WriteLine(reportPerVendite.Describe());
+        Console.WriteLine(reportPerSupporto.Describe());
+    }
+}
+
+public sealed class ReportTemplate : IPrototype<ReportTemplate>
+{
+    public ReportTemplate(string title, List<string> sections)
+    {
+        Title = title;
+        Sections = sections;
+    }
+
+    public string Title { get; set; }
+
+    public List<string> Sections { get; }
+
+    public ReportTemplate Clone()
+    {
+        return new ReportTemplate(Title, new List<string>(Sections));
+    }
+
+    public string Describe()
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine($"Titolo: {Title}");
+        builder.AppendLine("Sezioni:");
+        foreach (var section in Sections)
+        {
+            builder.AppendLine($" - {section}");
+        }
+
+        return builder.ToString();
+    }
+}
+
+public interface IPrototype<out T>
+{
+    T Clone();
+}

--- a/5 Pattern e Database/Program.cs
+++ b/5 Pattern e Database/Program.cs
@@ -15,6 +15,7 @@ using PatternEDatabase.Proxy;
 using PatternEDatabase.Mvp;
 using PatternEDatabase.Mediator;
 using PatternEDatabase.Iterator;
+using PatternEDatabase.Prototype;
 using SQLiteExamples;
 
 namespace PatternEDatabaseApp;
@@ -27,7 +28,7 @@ public static class Program
         {
             if (!TryRunDemo(args[0]))
             {
-                Console.WriteLine("Argomento non valido. Opzioni disponibili: mvvc, sqlite, singleton, observer, command, state, builder, factory, facade, decorator, chain, bridge, adapter, composite, flyweight, proxy, mediator.");
+                Console.WriteLine("Argomento non valido. Opzioni disponibili: mvvc, sqlite, singleton, observer, command, state, builder, factory, facade, decorator, chain, bridge, adapter, composite, flyweight, proxy, mediator, iterator, prototype.");
             }
 
             return;
@@ -56,6 +57,7 @@ public static class Program
             Console.WriteLine("17. MVP");
             Console.WriteLine("18. Mediator");
             Console.WriteLine("19. Iterator");
+            Console.WriteLine("20. Prototype");
             Console.WriteLine(" Q. Esci");
             Console.WriteLine();
             Console.Write("Seleziona un'opzione: ");
@@ -164,8 +166,14 @@ public static class Program
             case "18":
             case "mediator":
                 MediatorPatternDemo.Run();
+                return true;
             case "iterator":
+            case "19":
                 IteratorPatternDemo.Run();
+                return true;
+            case "20":
+            case "prototype":
+                PrototypePatternDemo.Run();
                 return true;
             default:
                 return false;


### PR DESCRIPTION
### Motivation
- Aggiungere un esempio pratico del pattern Prototype alla raccolta di pattern per mostrare come clonare e personalizzare oggetti template.
- Rendere il demo selezionabile dal menu principale dell'app per poter eseguire l'esempio in modo coerente con gli altri pattern.

### Description
- Aggiunto il file `5 Pattern e Database/37 Prototype/PrototypePatternDemo.cs` che definisce `ReportTemplate`, l'interfaccia `IPrototype<T>` e il demo `PrototypePatternDemo.Run()` che dimostra la clonazione profonda di liste di sezioni.
- Importato lo spazio dei nomi `PatternEDatabase.Prototype` in `Program.cs` e aggiunta l'opzione di menu `20. Prototype` per l'esecuzione interattiva.
- Estesa la gestione degli argomenti e il messaggio di errore per includere `prototype` e la nuova voce di menu tra le opzioni disponibili.

### Testing
- Non sono stati eseguiti test automatici sul codice modificato.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696de18b6e7c83249c35333578546d85)