### PR TITLE
Add Memento pattern demo to Pattern e Database

### DIFF
--- a/5 Pattern e Database/38 Memento/MementoPatternDemo.cs
+++ b/5 Pattern e Database/38 Memento/MementoPatternDemo.cs
@@ -1,0 +1,99 @@
+using System.Text;
+
+namespace PatternEDatabase.Memento;
+
+public static class MementoPatternDemo
+{
+    public static void Run()
+    {
+        var editor = new TextEditor("Nota iniziale");
+        var history = new EditorHistory();
+
+        history.Save(editor);
+        editor.Append(" + dettagli operativi");
+        history.Save(editor);
+        editor.Replace("Versione finale condivisa");
+
+        Console.WriteLine("--- Memento ---");
+        Console.WriteLine(editor.Describe());
+
+        history.Undo(editor);
+        Console.WriteLine("Dopo undo:");
+        Console.WriteLine(editor.Describe());
+
+        history.Undo(editor);
+        Console.WriteLine("Dopo altro undo:");
+        Console.WriteLine(editor.Describe());
+    }
+}
+
+public sealed class TextEditor
+{
+    public TextEditor(string content)
+    {
+        Content = content;
+    }
+
+    public string Content { get; private set; }
+
+    public void Append(string text)
+    {
+        Content += text;
+    }
+
+    public void Replace(string text)
+    {
+        Content = text;
+    }
+
+    public EditorMemento CreateMemento()
+    {
+        return new EditorMemento(Content, DateTime.Now);
+    }
+
+    public void Restore(EditorMemento memento)
+    {
+        Content = memento.Content;
+    }
+
+    public string Describe()
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine($"Contenuto: {Content}");
+        return builder.ToString();
+    }
+}
+
+public sealed class EditorMemento
+{
+    public EditorMemento(string content, DateTime savedAt)
+    {
+        Content = content;
+        SavedAt = savedAt;
+    }
+
+    public string Content { get; }
+
+    public DateTime SavedAt { get; }
+}
+
+public sealed class EditorHistory
+{
+    private readonly Stack<EditorMemento> _history = new();
+
+    public void Save(TextEditor editor)
+    {
+        _history.Push(editor.CreateMemento());
+    }
+
+    public void Undo(TextEditor editor)
+    {
+        if (_history.Count == 0)
+        {
+            return;
+        }
+
+        var memento = _history.Pop();
+        editor.Restore(memento);
+    }
+}

--- a/5 Pattern e Database/Program.cs
+++ b/5 Pattern e Database/Program.cs
@@ -16,6 +16,7 @@ using PatternEDatabase.Mvp;
 using PatternEDatabase.Mediator;
 using PatternEDatabase.Iterator;
 using PatternEDatabase.Prototype;
+using PatternEDatabase.Memento;
 using SQLiteExamples;
 
 namespace PatternEDatabaseApp;
@@ -28,7 +29,7 @@ public static class Program
         {
             if (!TryRunDemo(args[0]))
             {
-                Console.WriteLine("Argomento non valido. Opzioni disponibili: mvvc, sqlite, singleton, observer, command, state, builder, factory, facade, decorator, chain, bridge, adapter, composite, flyweight, proxy, mediator, iterator, prototype.");
+                Console.WriteLine("Argomento non valido. Opzioni disponibili: mvvc, sqlite, singleton, observer, command, state, builder, factory, facade, decorator, chain, bridge, adapter, composite, flyweight, proxy, mediator, iterator, prototype, memento.");
             }
 
             return;
@@ -58,6 +59,7 @@ public static class Program
             Console.WriteLine("18. Mediator");
             Console.WriteLine("19. Iterator");
             Console.WriteLine("20. Prototype");
+            Console.WriteLine("21. Memento");
             Console.WriteLine(" Q. Esci");
             Console.WriteLine();
             Console.Write("Seleziona un'opzione: ");
@@ -174,6 +176,10 @@ public static class Program
             case "20":
             case "prototype":
                 PrototypePatternDemo.Run();
+                return true;
+            case "21":
+            case "memento":
+                MementoPatternDemo.Run();
                 return true;
             default:
                 return false;


### PR DESCRIPTION
### Motivation
- Provide a concrete example of the Memento behavioral pattern to demonstrate saving and restoring object state for the "5 Pattern e Database" collection.
- Expose the new demo from the existing menu and CLI so it can be run alongside other pattern examples.

### Description
- Added a new demo file `5 Pattern e Database/38 Memento/MementoPatternDemo.cs` implementing `MementoPatternDemo`, `TextEditor`, `EditorMemento`, and `EditorHistory` to show `Save`/`Undo` operations with mementos.
- Integrated the demo into the application by adding `using PatternEDatabase.Memento;`, a menu entry (`"21. Memento"`), and CLI/help text updates in `5 Pattern e Database/Program.cs`.
- Wired `TryRunDemo` to recognize the `"memento"` and `"21"` inputs and invoke `MementoPatternDemo.Run()`.

### Testing
- No automated tests were run for this change (no build or test commands executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696de381a2548324860378f1f2cdd6e9)