### PR TITLE
Aggiungi demo del pattern Strategy e integrazione nel menu

### DIFF
--- a/5 Pattern e Database/39 Strategy/ExpressShippingStrategy.cs
+++ b/5 Pattern e Database/39 Strategy/ExpressShippingStrategy.cs
@@ -1,0 +1,15 @@
+namespace PatternEDatabase.Strategy;
+
+public sealed class ExpressShippingStrategy : IShippingStrategy
+{
+    public string Nome => "Express";
+
+    public decimal CalcolaCosto(Ordine ordine)
+    {
+        var baseCosto = 12m;
+        var costoPeso = ordine.PesoKg * 1.8m;
+        var costoDistanza = ordine.DistanzaKm * 0.08m;
+        var assicurazione = ordine.ValoreMerce * 0.01m;
+        return baseCosto + costoPeso + costoDistanza + assicurazione;
+    }
+}

--- a/5 Pattern e Database/39 Strategy/IShippingStrategy.cs
+++ b/5 Pattern e Database/39 Strategy/IShippingStrategy.cs
@@ -1,0 +1,8 @@
+namespace PatternEDatabase.Strategy;
+
+public interface IShippingStrategy
+{
+    string Nome { get; }
+
+    decimal CalcolaCosto(Ordine ordine);
+}

--- a/5 Pattern e Database/39 Strategy/Ordine.cs
+++ b/5 Pattern e Database/39 Strategy/Ordine.cs
@@ -1,0 +1,15 @@
+namespace PatternEDatabase.Strategy;
+
+public sealed class Ordine
+{
+    public Ordine(decimal pesoKg, int distanzaKm, decimal valoreMerce)
+    {
+        PesoKg = pesoKg;
+        DistanzaKm = distanzaKm;
+        ValoreMerce = valoreMerce;
+    }
+
+    public decimal PesoKg { get; }
+    public int DistanzaKm { get; }
+    public decimal ValoreMerce { get; }
+}

--- a/5 Pattern e Database/39 Strategy/PickupShippingStrategy.cs
+++ b/5 Pattern e Database/39 Strategy/PickupShippingStrategy.cs
@@ -1,0 +1,11 @@
+namespace PatternEDatabase.Strategy;
+
+public sealed class PickupShippingStrategy : IShippingStrategy
+{
+    public string Nome => "Ritiro in sede";
+
+    public decimal CalcolaCosto(Ordine ordine)
+    {
+        return 0m;
+    }
+}

--- a/5 Pattern e Database/39 Strategy/Spedizione.cs
+++ b/5 Pattern e Database/39 Strategy/Spedizione.cs
@@ -1,0 +1,23 @@
+namespace PatternEDatabase.Strategy;
+
+public sealed class Spedizione
+{
+    public Spedizione(Ordine ordine, IShippingStrategy strategia)
+    {
+        Ordine = ordine;
+        Strategia = strategia;
+    }
+
+    public Ordine Ordine { get; }
+    public IShippingStrategy Strategia { get; private set; }
+
+    public decimal CalcolaCosto()
+    {
+        return Strategia.CalcolaCosto(Ordine);
+    }
+
+    public void CambiaStrategia(IShippingStrategy strategia)
+    {
+        Strategia = strategia;
+    }
+}

--- a/5 Pattern e Database/39 Strategy/StandardShippingStrategy.cs
+++ b/5 Pattern e Database/39 Strategy/StandardShippingStrategy.cs
@@ -1,0 +1,14 @@
+namespace PatternEDatabase.Strategy;
+
+public sealed class StandardShippingStrategy : IShippingStrategy
+{
+    public string Nome => "Standard";
+
+    public decimal CalcolaCosto(Ordine ordine)
+    {
+        var baseCosto = 5m;
+        var costoPeso = ordine.PesoKg * 1.2m;
+        var costoDistanza = ordine.DistanzaKm * 0.05m;
+        return baseCosto + costoPeso + costoDistanza;
+    }
+}

--- a/5 Pattern e Database/39 Strategy/StrategyPatternDemo.cs
+++ b/5 Pattern e Database/39 Strategy/StrategyPatternDemo.cs
@@ -1,0 +1,31 @@
+using System.Globalization;
+
+namespace PatternEDatabase.Strategy;
+
+public static class StrategyPatternDemo
+{
+    public static void Run()
+    {
+        Console.WriteLine("*** Strategy Pattern: calcolo spedizione ***\n");
+
+        var ordine = new Ordine(pesoKg: 4.2m, distanzaKm: 120, valoreMerce: 350m);
+        var spedizione = new Spedizione(ordine, new StandardShippingStrategy());
+
+        StampaDettagli(spedizione);
+
+        spedizione.CambiaStrategia(new ExpressShippingStrategy());
+        StampaDettagli(spedizione);
+
+        spedizione.CambiaStrategia(new PickupShippingStrategy());
+        StampaDettagli(spedizione);
+
+        Console.WriteLine("\nIl contesto cambia strategia senza modificare la logica interna.");
+    }
+
+    private static void StampaDettagli(Spedizione spedizione)
+    {
+        var costo = spedizione.CalcolaCosto();
+        Console.WriteLine($"Strategia: {spedizione.Strategia.Nome}");
+        Console.WriteLine($"Costo spedizione: {costo.ToString("C", CultureInfo.GetCultureInfo("it-IT"))}\n");
+    }
+}

--- a/5 Pattern e Database/Program.cs
+++ b/5 Pattern e Database/Program.cs
@@ -17,6 +17,7 @@ using PatternEDatabase.Mediator;
 using PatternEDatabase.Iterator;
 using PatternEDatabase.Prototype;
 using PatternEDatabase.Memento;
+using PatternEDatabase.Strategy;
 using SQLiteExamples;
 
 namespace PatternEDatabaseApp;
@@ -29,7 +30,7 @@ public static class Program
         {
             if (!TryRunDemo(args[0]))
             {
-                Console.WriteLine("Argomento non valido. Opzioni disponibili: mvvc, sqlite, singleton, observer, command, state, builder, factory, facade, decorator, chain, bridge, adapter, composite, flyweight, proxy, mediator, iterator, prototype, memento.");
+                Console.WriteLine("Argomento non valido. Opzioni disponibili: mvvc, sqlite, singleton, observer, command, state, builder, factory, facade, decorator, chain, bridge, adapter, composite, flyweight, proxy, mediator, iterator, prototype, memento, strategy.");
             }
 
             return;
@@ -60,6 +61,7 @@ public static class Program
             Console.WriteLine("19. Iterator");
             Console.WriteLine("20. Prototype");
             Console.WriteLine("21. Memento");
+            Console.WriteLine("22. Strategy");
             Console.WriteLine(" Q. Esci");
             Console.WriteLine();
             Console.Write("Seleziona un'opzione: ");
@@ -180,6 +182,10 @@ public static class Program
             case "21":
             case "memento":
                 MementoPatternDemo.Run();
+                return true;
+            case "22":
+            case "strategy":
+                StrategyPatternDemo.Run();
                 return true;
             default:
                 return false;


### PR DESCRIPTION
### Motivation
- Aggiungere un esempio didattico del pattern Strategy per mostrare come variare algoritmi di calcolo della spedizione senza modificare il contesto.
- Integrare la demo nel menu principale e nella gestione degli argomenti CLI per poterla eseguire dall'applicazione esistente.

### Description
- Aggiunti i file del nuovo esempio `5 Pattern e Database/39 Strategy/*` con l'interfaccia `IShippingStrategy`, le strategie `StandardShippingStrategy`, `ExpressShippingStrategy` e `PickupShippingStrategy`, la classe contesto `Spedizione`, il modello `Ordine` e la demo `StrategyPatternDemo`.
- Collegata la nuova demo importando il namespace `PatternEDatabase.Strategy` in `Program.cs` e aggiungendo l'opzione di menu `22. Strategy`.
- Aggiornata la gestione degli argomenti CLI per riconoscere l'opzione `strategy` e incluso `strategy` nel messaggio di aiuto degli argomenti non validi.
- Il codice dimostra il cambio di strategia in fase di esecuzione e stampa i dettagli di costo formattati localmente.

### Testing
- Nessun test automatico eseguito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696de48f39408324852d0c7ab76b5854)